### PR TITLE
Preemptively disable FLoC

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -18,6 +18,7 @@ http {
             default_type application/octet-stream;
             sendfile on;
             gzip on;
+            add_header Permissions-Policy interest-cohort=();
         }
     }
 }


### PR DESCRIPTION
 - Shouldn't be entered anyways as there are no ads nor JS accessing the
   FLoC API, but this makes it sure.